### PR TITLE
Provide a node.js api

### DIFF
--- a/files.js
+++ b/files.js
@@ -1,0 +1,77 @@
+const path = require("path");
+const fs = require("fs");
+
+const CWD = process.cwd();
+let destination = path.resolve(CWD, "dist");
+
+function getFilepath(p) {
+  if (!path.isAbsolute(p)) {
+    p = path.resolve(CWD, p);
+  }
+
+  return new Promise((resolve, reject) => {
+    fs.stat(p, (err, stats) => {
+      if (err) return reject(err);
+      if (stats.isFile()) return resolve(path.relative(CWD, p));
+      reject(Error(`UnknownError: "${path.relative(CWD, p)}" is not a file.`));
+    });
+  });
+}
+
+function readPackage(p) {
+  if (!path.isAbsolute(p)) p = path.resolve(CWD, p);
+  return new Promise((resolve, reject) => {
+    if (!fs.statSync(p).isFile()) {
+      return reject(
+        Error(`UnknownError: "${path.relative(CWD, p)}" is not a file`)
+      );
+    }
+
+    fs.readFile(p, (err, buff) => {
+      if (err) return reject(err);
+      resolve(buff.toString());
+    });
+  });
+}
+
+function writePackage(data) {
+  const filename = path.resolve(destination, "package.json");
+  return new Promise((resolve, reject) => {
+    fs.writeFile(filename, data, err => {
+      if (err) return reject(err);
+      resolve();
+    });
+  });
+}
+
+function copyFile(src) {
+  const filename = path.basename(src);
+  return new Promise((resolve, reject) => {
+    fs.copyFile(src, path.resolve(destination, filename), err => {
+      if (err) return reject(err);
+      resolve();
+    });
+  });
+}
+
+module.exports = directoryOfBuild => {
+  if (!path.isAbsolute(directoryOfBuild)) {
+    directoryOfBuild = path.resolve(CWD, directoryOfBuild);
+  }
+
+  const stats = fs.statSync(directoryOfBuild);
+  if (stats.isDirectory()) {
+    destination = directoryOfBuild;
+  } else {
+    throw Error(
+      `TargetDirectoryError: "${directoryOfBuild}" is not a directory`
+    );
+  }
+
+  return {
+    getFilepath,
+    readPackage,
+    writePackage,
+    copyFile
+  };
+};

--- a/files.js
+++ b/files.js
@@ -18,6 +18,7 @@ function getFilepath(p) {
   });
 }
 
+/** @param {string} p path to package.json */
 function readPackage(p) {
   if (!path.isAbsolute(p)) p = path.resolve(CWD, p);
   return new Promise((resolve, reject) => {

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const objectPath = require("object-path");
 const args = yargs
   .scriptName("package-shipit")
   .version()
+  .pkgConf("shipit")
   .option("no-overwrite", {
     boolean: true,
     describe: "Terminates process rather than overwriting old target path",

--- a/index.js
+++ b/index.js
@@ -1,0 +1,47 @@
+const path = require("path");
+const main = require("./main");
+const files = require("./files");
+/**
+ * @typedef Options
+ * @property {string[]} [omit] package.json keys (dot-syntax works)
+ * @property {string[]} [include] package.json keys (dot-syntax works)
+ * @property {string} [useFile] use this file as `package.json`
+ * @property {string} [target] directory to write files
+ * @property {string[]} [copyFiles] copy files to dist directory
+ * @property {'tab'|'2'|'4'} [indent] */
+
+/** @param {Options} [options] */
+module.exports = function(options) {
+  if (!options) options = {};
+
+  const target = resolve(options.target || "./dist");
+  const package_json = options.useFile || resolve("./package.json");
+  const fileWriter = files(target);
+  const copyFiles = options.copyFiles || [];
+
+  fileWriter
+    .readPackage(package_json)
+    .then(package_json => {
+      return main(package_json, {
+        omit: options.omit || [],
+        include: options.include || [],
+        indent: indentation(options.indent || "2")
+      });
+    })
+    .then(package_json => {
+      return fileWriter.writePackage(package_json);
+    })
+    .then(() => {
+      copyFiles.forEach(filename => fileWriter.copyFile(resolve(filename)));
+    });
+};
+
+function resolve(p) {
+  return path.resolve(process.cwd(), p);
+}
+
+function indentation(indent) {
+  if (indent === "tab") return "\t";
+  if (indent === "4") return "    ";
+  return "  ";
+}

--- a/index.test.js
+++ b/index.test.js
@@ -1,0 +1,4 @@
+require("./index")({
+  indent: "tab",
+  copyFiles: []
+});

--- a/main.js
+++ b/main.js
@@ -9,7 +9,6 @@ const DEFAULT_KEYS = [
   "bugs",
   "main",
   "module",
-  "scripts",
   "dependencies",
   "peerDependencies",
   "license"
@@ -59,15 +58,20 @@ function makePackage(config_data, options) {
   }
 
   const required_keys = ["name", "version"];
+  const required_config = {};
   for (const key of required_keys) {
     if (objectPath(config).has(key)) {
-      objectPath(new_config).set(key, objectPath(config).get(key));
+      objectPath(required_config).set(key, objectPath(config).get(key));
     } else {
       throw Error(`Missing required key ${key}`);
     }
   }
 
-  return JSON.stringify(new_config, null, options.indent);
+  return JSON.stringify(
+    Object.assign(required_config, new_config),
+    null,
+    options.indent
+  );
 }
 
 /**

--- a/main.js
+++ b/main.js
@@ -7,6 +7,7 @@ const DEFAULT_KEYS = [
   "keywords",
   "repository",
   "bugs",
+  "bin",
   "main",
   "module",
   "dependencies",

--- a/main.js
+++ b/main.js
@@ -1,0 +1,87 @@
+const objectPath = require("object-path");
+
+const DEFAULT_KEYS = [
+  "author",
+  "contributors",
+  "description",
+  "keywords",
+  "repository",
+  "bugs",
+  "main",
+  "module",
+  "scripts",
+  "dependencies",
+  "peerDependencies",
+  "license"
+];
+
+/**
+ * @typedef Options
+ * @property {string[]} omit
+ * @property {string[]} include
+ * @property {string} indent
+ */
+
+/**
+ * makePackage
+ * @param {string} config_data
+ * @param {Options} options
+ * @returns {string}
+ */
+function makePackage(config_data, options) {
+  options = {
+    omit: options.omit || [],
+    include: options.include || [],
+    indent: options.indent || "  "
+  };
+
+  let config;
+  try {
+    config = JSON.parse(config_data);
+  } catch (error) {
+    throw Error("ParseError: 'package.json' is not valid");
+  }
+
+  const new_config = {};
+
+  const keys = [
+    ...DEFAULT_KEYS.map(inclusion),
+    ...options.include.map(inclusion),
+    ...options.omit.map(omission)
+  ].sort(require("./path-sort"));
+
+  for (const { key, action } of keys) {
+    if (action === "include" && objectPath(config).has(key)) {
+      objectPath(new_config).set(key, objectPath(config).get(key));
+    } else if (action === "omit") {
+      objectPath(new_config).del(key);
+    }
+  }
+
+  const required_keys = ["name", "version"];
+  for (const key of required_keys) {
+    if (objectPath(config).has(key)) {
+      objectPath(new_config).set(key, objectPath(config).get(key));
+    } else {
+      throw Error(`Missing required key ${key}`);
+    }
+  }
+
+  return JSON.stringify(new_config, null, options.indent);
+}
+
+/**
+ * @param {string} key
+ * @returns {{ key: string, action: 'omit' }} */
+function omission(key) {
+  return { key, action: "omit" };
+}
+
+/**
+ * @param {string} key
+ * @returns {{ key: string, action: 'include' }} */
+function inclusion(key) {
+  return { key, action: "include" };
+}
+
+module.exports = makePackage;

--- a/main.js
+++ b/main.js
@@ -16,9 +16,9 @@ const DEFAULT_KEYS = [
 
 /**
  * @typedef Options
- * @property {string[]} omit
- * @property {string[]} include
- * @property {string} indent
+ * @property {string[]} [omit]
+ * @property {string[]} [include]
+ * @property {string} [indent]
  */
 
 /**

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "package.shipit",
   "version": "0.0.1-3",
   "description": "copy the important parts of package.json into a smaller, shippable package.json for publishing",
-  "main": "index.js",
+  "main": "./index.js",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com:walston/package.shipit.git"
@@ -27,16 +27,5 @@
     "colors": "^1.3.3",
     "object-path": "^0.11.4",
     "yargs": "^13.2.4"
-  },
-  "scripts": {
-    "pretest": "rm -rf dist/**/*",
-    "test": "./shipit"
-  },
-  "shipit": {
-    "indent": "2",
-    "omit": "shipit,scripts",
-    "copy-file": [
-      "./README.md"
-    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "scripts": {
     "pretest": "rm -rf dist/**/*",
-    "test": "node ./index.js"
+    "test": "./shipit"
   },
   "shipit": {
     "indent": "2",

--- a/package.json
+++ b/package.json
@@ -27,5 +27,16 @@
     "colors": "^1.3.3",
     "object-path": "^0.11.4",
     "yargs": "^13.2.4"
+  },
+  "scripts": {
+    "pretest": "rm -rf dist/**/*",
+    "test": "node ./index.js"
+  },
+  "shipit": {
+    "indent": "2",
+    "omit": "shipit,scripts",
+    "copy-file": [
+      "./README.md"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.1-3",
   "description": "copy the important parts of package.json into a smaller, shippable package.json for publishing",
   "main": "./index.js",
+  "bin": {
+    "shipit": "./shipit"
+  },
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com:walston/package.shipit.git"

--- a/shipit
+++ b/shipit
@@ -1,3 +1,4 @@
+#! /usr/bin/env node
 const path = require("path");
 const fs = require("fs");
 const yargs = require("yargs");

--- a/shipit
+++ b/shipit
@@ -1,6 +1,6 @@
 #! /usr/bin/env node
 const yargs = require("yargs");
-const handlePackage = require("./main");
+const main = require("./main");
 
 const args = yargs
   .scriptName("package-shipit")
@@ -23,19 +23,20 @@ const args = yargs
     example: "--copy-file=README.md -c=CHANGELOG.md"
   })
   .option("omit", {
-    string: true,
     alias: "o",
-    describe:
-      "Omit certain keys/sub-keys from being included in the output package.json",
-    example: "--omit=scripts,contributors",
-    default: ""
+    array: true,
+    string: true,
+    describe: "Omit certain keys/sub-keys from the output package.json",
+    example: "--omit=scripts -o=contributors",
+    default: [""]
   })
   .option("include", {
-    string: true,
     alias: "i",
+    array: true,
+    string: true,
     describe: "Include keys/sub-keys in the output package.json",
-    example: "--include=eslint,scripts.start,scripts.test",
-    default: ""
+    example: "--include=eslint -i=scripts.start,scripts.test",
+    default: [""]
   })
   .option("indent", {
     string: true,
@@ -50,24 +51,32 @@ const indent = (function(arg) {
   return "  ";
 })(args.indent);
 
-const fileHandler = require("./files")(args._[0] || "dist");
+const files = require("./files")(args._[0] || "dist");
 
-async function main() {
-  const pkg = await fileHandler.readPackage(args["use-file"]);
-  const postage_options = {
+async function execute() {
+  const package_json = await files.readPackage(args["use-file"]);
+  const publish_ready_package_json = main(package_json, {
     indent,
-    include: args["include"].split(","),
-    omit: args["omit"].split(",")
-  };
-  const publish_ready_package_json = handlePackage(pkg, postage_options);
+    include: args["include"].reduce(flattenKeySets, []),
+    omit: args["omit"].reduce(flattenKeySets, [])
+  });
 
-  await fileHandler.writePackage(publish_ready_package_json);
+  await files.writePackage(publish_ready_package_json);
 
   const files_to_copy = args["copy-file"];
-  files_to_copy.forEach(p => fileHandler.copyFile(p));
+  files_to_copy.forEach(p => files.copyFile(p));
 }
 
-main().catch(err => {
+/**
+ * @param {string[]} acc
+ * @param {string} csv
+ * @returns {string[]}
+ */
+function flattenKeySets(acc, csv) {
+  return acc.concat(csv.split(","));
+}
+
+execute().catch(err => {
   console.error(err);
   process.exit(1);
 });

--- a/shipit
+++ b/shipit
@@ -1,7 +1,6 @@
 #! /usr/bin/env node
-const path = require("path");
-const fs = require("fs");
 const yargs = require("yargs");
+const handlePackage = require("./main");
 
 const args = yargs
   .scriptName("package-shipit")
@@ -14,7 +13,7 @@ const args = yargs
   })
   .option("use-file", {
     describe: "Use provided file as `package.json`",
-    default: path.join(process.cwd(), "package.json")
+    default: "package.json"
   })
   .option("copy-file", {
     alias: "c",
@@ -51,50 +50,24 @@ const indent = (function(arg) {
   return "  ";
 })(args.indent);
 
-const path_to_original = (function(uri) {
-  if (!fs.existsSync(uri)) {
-    const rel = path.relative(process.cwd(), uri);
-    console.error(`Cannot use "${rel}", file does not exist`);
-    process.exit(1);
-  }
-  if (uri[0] === "/") return uri;
-  return path.join(process.cwd(), uri);
-})(args["use-file"]);
+const fileHandler = require("./files")(args._[0] || "dist");
 
-const path_to_output = (function(uri) {
-  /** @todo check to ensure `uri` is a directory */
-  if (!fs.existsSync(uri)) {
-    const rel = path.relative(process.cwd(), uri);
-    console.error(`Cannot write to "${rel}", directory does not exist`);
-    process.exit(1);
-  }
-  uri = path.join(uri, "package.json");
-  if (uri[0] === "/") return uri;
-  return path.join(process.cwd(), uri);
-})(args._[0] || path.join(process.cwd(), "dist"));
-
-fs.readFile(path_to_original, (err, data) => {
-  if (err) throw Error(`ReadError: could not access ${path_to_original}`);
-
-  const pkg = require("./main")(data.toString(), {
+async function main() {
+  const pkg = await fileHandler.readPackage(args["use-file"]);
+  const postage_options = {
     indent,
-    omit: args.omit.split(","),
-    include: args.include.split(",")
-  });
+    include: args["include"].split(","),
+    omit: args["omit"].split(",")
+  };
+  const publish_ready_package_json = handlePackage(pkg, postage_options);
 
-  fs.writeFile(path_to_output, pkg, err => {
-    if (err) throw Error(`WriteError: could not write to ${path_to_output}`);
-    copyFiles().catch(console.error);
-  });
-});
+  await fileHandler.writePackage(publish_ready_package_json);
 
-async function copyFiles() {
-  const files = args["copy-file"];
-  for (const filename of files) {
-    const src = path.resolve(process.cwd(), filename);
-    const dest = path.resolve(path.dirname(path_to_output), filename);
-    fs.copyFile(src, dest, err => {
-      if (err) throw err;
-    });
-  }
+  const files_to_copy = args["copy-file"];
+  files_to_copy.forEach(p => fileHandler.copyFile(p));
 }
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
The goal is to minimize interaction with a CLI tool and programmatically fire off the copy.

- [x] Configuration via package.json
- [x] Move business logic into isolated module
- [x] Abstract out logic for file-reading/writing (for testibility)
- [x] Provide Node API w/ options object matching package configuration

Resolves #2 