### PR TITLE
Files for `npm` are copied automatically.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@ const files = require("./files");
  * @property {string[]} [include] package.json keys (dot-syntax works)
  * @property {string} [useFile] use this file as `package.json`
  * @property {string} [target] directory to write files
- * @property {string[]} [copyFiles] copy files to dist directory
  * @property {'tab'|'2'|'4'} [indent] */
 
 /** @param {Options} [options] */
@@ -17,7 +16,6 @@ module.exports = function(options) {
   const target = resolve(options.target || "./dist");
   const package_json = options.useFile || resolve("./package.json");
   const fileWriter = files(target);
-  const copyFiles = options.copyFiles || [];
 
   fileWriter
     .readPackage(package_json)
@@ -32,7 +30,7 @@ module.exports = function(options) {
       return fileWriter.writePackage(package_json);
     })
     .then(() => {
-      copyFiles.forEach(filename => fileWriter.copyFile(resolve(filename)));
+      fileWriter.copyFilesFrom(process.cwd());
     });
 };
 

--- a/shipit
+++ b/shipit
@@ -15,13 +15,6 @@ const args = yargs
     describe: "Use provided file as `package.json`",
     default: "package.json"
   })
-  .option("copy-file", {
-    alias: "c",
-    array: true,
-    string: true,
-    describe: "Copy this file to target directory with package.json",
-    example: "--copy-file=README.md -c=CHANGELOG.md"
-  })
   .option("omit", {
     alias: "o",
     array: true,
@@ -62,9 +55,7 @@ async function execute() {
   });
 
   await files.writePackage(publish_ready_package_json);
-
-  const files_to_copy = args["copy-file"];
-  files_to_copy.forEach(p => files.copyFile(p));
+  await files.copyFilesFrom(process.cwd());
 }
 
 /**


### PR DESCRIPTION
Automatically copy over a `changelog.???`, `readme.???` and `license`
Extensions are not required, and all extensions are supported.
Resolves #10 